### PR TITLE
Naming Conventions

### DIFF
--- a/CogDoc/CogDoc.pyproj
+++ b/CogDoc/CogDoc.pyproj
@@ -6,8 +6,7 @@
     <ProjectGuid>14beb976-43a6-46a2-b19c-040d620c5217</ProjectGuid>
     <ProjectHome>.</ProjectHome>
     <ProjectTypeGuids>{1b580a1a-fdb3-4b32-83e1-6407eb2722e6};{349c5851-65df-11da-9384-00065b846f21};{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
-    <StartupFile>
-    </StartupFile>
+    <StartupFile>main.py</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>

--- a/CogDoc/main.py
+++ b/CogDoc/main.py
@@ -1,9 +1,7 @@
 import os
-import src
-import src.Classes
-import src.Classes.Util
 from src.Classes.Util import Util as Util
-from lxml import etree
+from src.Classes.Query import Query as Query
+from lxml import etree 
 
 
 __location__ = os.path.realpath(
@@ -16,6 +14,19 @@ parser = etree.XMLParser(recover=True, remove_blank_text=True, ns_clean=True)
 xmlData = etree.fromstring(spec, parser=parser)
 ns = "{" + xmlData.nsmap[None] + "}"
 
+totalDataItems = 0
+totalFilters = 0
+
 queries = Util.getQueries(xmlData, ns)
 for query in queries:
-    query.printStats()
+    totalDataItems += len(query.dataItems)
+    totalFilters += len(query.filters)
+
+totalQueries = len(queries)
+print(
+    "DataItems: ", totalDataItems, 
+    "Filters: ", totalFilters,
+    "Queries: ", totalQueries
+    )
+[print(item.json()) for item in queries]
+

--- a/CogDoc/src/Classes/DatItem.py
+++ b/CogDoc/src/Classes/DatItem.py
@@ -1,9 +1,9 @@
 class DatItem(object):
     """description of class"""
-    def __init__(self, _name, _aggregate, _rollupAggregate, _sort, _expression, _element):
-        self.name = _name
-        self.aggregate = _aggregate
-        self.rollupAggregate = _rollupAggregate
-        self.sort = _sort
-        self.expression = _expression
-        self.element = _element
+    def __init__(self, name, aggregate, rollupAggregate, sort, expression, element):
+        self.name = name
+        self.aggregate = aggregate
+        self.rollupAggregate = rollupAggregate
+        self.sort = sort
+        self.expression = expression
+        self.element = element

--- a/CogDoc/src/Classes/DetFilter.py
+++ b/CogDoc/src/Classes/DetFilter.py
@@ -1,6 +1,6 @@
 class DetFilter(object):
     """description of class"""
-    def __init__(self, _expression, _usage, _element):
-        self.expression = _expression
-        self.usage = _usage
-        self.element = _element
+    def __init__(self, expression, usage, element):
+        self.expression = expression
+        self.usage = usage
+        self.element = element

--- a/CogDoc/src/Classes/Query.py
+++ b/CogDoc/src/Classes/Query.py
@@ -1,18 +1,20 @@
 class Query(object):
     """description of class"""
-    def __init__(self, _name, _source, _joins, _dataItems, _filters, _slicers, _element):
-        self.name = _name
-        self.source = _source
-        self.joins = _joins
-        self.dataItems = _dataItems
-        self.filters = _filters
-        self.slicers = _slicers
-        self.element = _element
+    def __init__(self, name, source, joins, dataItems, filters, slicers, element):
+        self.name = name
+        self.source = source
+        self.joins = joins
+        self.dataItems = dataItems
+        self.filters = filters
+        self.slicers = slicers
+        self.element = element
 
-    def printStats(self):
-        print(
-            "QueryName: ", self.name, 
-            ", Source: ", self.source,
-            ", DataItems: ", len( self.dataItems ),
-            ", Filters: ", len(self.filters)
-            )
+    def json(self):
+        return {
+            'name': self.name,
+            'source': self.source,
+            'joins': self.joins,
+            'dataItems': len( self.dataItems ),
+            'filters': len(self.filters),
+            'slicers': self.slicers,
+            }

--- a/CogDoc/src/Classes/Util.py
+++ b/CogDoc/src/Classes/Util.py
@@ -1,66 +1,70 @@
-import src
-import src.Classes
-import src.Classes.DatItem as DI
-import src.Classes.DetFilter as DF
-import src.Classes.Query as Q
+from src.Classes.DatItem import DatItem as DatItem
+from src.Classes.DetFilter import DetFilter as DetFilter
+from src.Classes.Query import Query as Query
 
 
 class Util(object):
     #Used for static methods/functions
 
-    def getQueries(xmlSpec, namespace):
-        print("retreiving queries")
+    def getQueries(element, namespace):
         queries=[]
-        queriesIter = xmlSpec.iter(namespace + "query")
-        for query in queriesIter:
-            if query[0][0].tag == namespace+"queryRef":
-                source = query[0][0].get("refQuery")
-            if query[0][0].tag == namespace+"model":
+        
+        itemGroup = element.iter(namespace + "query")
+        for item in itemGroup:
+            if item[0][0].tag == namespace+"queryRef":
+                source = item[0][0].get("refQuery")
+            if item[0][0].tag == namespace+"model":
                 source = "model"
-            qry = Q.Query(
-                    _name = query.get("name"),
-                    _source = source,
-                    _joins = None,
-                    _dataItems = Util.getDataItems(query, namespace),
-                    #getDataItems,
-                    _filters = Util.getDetailFilters(query, namespace),
-                    _slicers = None,
-                    _element = query
+            queries.append( 
+                Query(
+                    name = item.get("name"),
+                    source = source,
+                    joins = None,
+                    dataItems = Util.getDataItems(item, namespace),
+                    filters = Util.getDetailFilters(item, namespace),
+                    slicers = None,
+                    element = item
                 )
-            queries.append(qry)
+            )
+        
         return queries
         
 
     def getDataItems(element, namespace):
         dataItems = []
-        dItemsIter = element.iter(namespace+"dataItem")
-        for dataItem in dItemsIter:
-            dI = DI.DatItem(
-                _name = dataItem.get("name"),
-                _aggregate = dataItem.get("aggregate"),
-                _rollupAggregate = dataItem.get("rollupAggregate"),
-                _sort = dataItem.get("sort"),
-                _expression = dataItem[0].text,
-                _element = dataItem
+        
+        itemGroup = element.iter(namespace+"dataItem")
+        for item in itemGroup:
+            dataItems.append(
+                DatItem(
+                    name = item.get("name"),
+                    aggregate = item.get("aggregate"),
+                    rollupAggregate = item.get("rollupAggregate"),
+                    sort = item.get("sort"),
+                    expression = item[0].text,
+                    element = item
                 )
-            dataItems.append(dI)
-         
+            )
+        
         return dataItems
     
 
     def getDetailFilters(element, namespace):
         detailedFilters = []
-        detFiltIter = element.iter(namespace + "detailFilter")
-        if detFiltIter:
-            for detFilter in detFiltIter:
-                if detFilter.get("usage"):
-                    usage = detFilter.get("usage")
+        
+        itemGroup = element.iter(namespace + "detailFilter")
+        if itemGroup:
+            for item in itemGroup:
+                if item.get("usage"):
+                    usage = item.get("usage")
                 else:
                     usage = "required"
-                df = DF.DetFilter(
-                    _expression = detFilter[0].text,
-                    _usage = usage,
-                    _element = detFilter
+                
+                detailFilter = DetFilter(
+                    expression = item[0].text,
+                    usage = usage,
+                    element = item
                     )
-                detailedFilters.append(df)
+                detailedFilters.append(detailFilter)
+        
         return detailedFilters


### PR DESCRIPTION
In this update I renamed all the ...iter variables to itemGroup, and all of the for loops to use item.
I also removed the variable to instantiate the classes in the getXXX() queries, and instead just instantiate directly into the list-append method.
I also cleanded up the imports so the method calls don't require don notation.
I also removed the _ prefix from the class parameters.  Not sure where I got the idea I was supposed to do that, but it surely wasn't necessary...

closes #12