### PR TITLE
Html export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+
+Output

--- a/CogDoc/CogDoc.pyproj
+++ b/CogDoc/CogDoc.pyproj
@@ -26,8 +26,10 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
+    <Folder Include="Output\" />
     <Folder Include="src\" />
     <Folder Include="src\Classes\" />
+    <Folder Include="src\Templates\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="main.py">
@@ -56,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="DCL0001 - Position Detail Report.xml" />
+    <Content Include="src\Templates\template.html" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.Web.targets" />
   <!-- Specify pre- and post-build commands in the BeforeBuild and 

--- a/CogDoc/main.py
+++ b/CogDoc/main.py
@@ -19,7 +19,7 @@ totalFilters = 0
 
 reports = Util.getReports(xmlData, ns)
 
-for report in reports:
+for index,report in enumerate(reports):
     print(report.json())
 
     for query in report.queries:
@@ -33,5 +33,7 @@ for report in reports:
         "Queries: ", totalQueries
         )
     [print(item.json()) for item in report.queries]
+
+    Util.exportHTML("report"+str(index)+".html","Report "+str(index),"HEADER",str(report.json()),"FOOTER")
 
 

--- a/CogDoc/src/Classes/Util.py
+++ b/CogDoc/src/Classes/Util.py
@@ -1,3 +1,4 @@
+import os
 from src.Classes.Report import Report
 from src.Classes.DataItem import DataItem
 from src.Classes.DetailFilter import DetailFilter
@@ -95,3 +96,20 @@ class Util(object):
                 )
         
         return detailFilters
+
+
+    def exportHTML(filename, title, header, content, footer):
+        with open(os.getcwd()+"\\src\\Templates\\template.html","r") as templateFile:
+            template = templateFile.read()
+        templateFile.close()
+
+        template = template.replace("[[TITLE]]",title)
+        template = template.replace("[[HEADER]]",header)
+        template = template.replace("[[CONTENT]]",content)
+        template = template.replace("[[FOOTER]]",footer)
+
+        with open(os.getcwd()+"\\Output\\"+filename,"w") as outFile:
+            outFile.write(template)
+        outFile.close()
+
+

--- a/CogDoc/src/Templates/template.html
+++ b/CogDoc/src/Templates/template.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>[[TITLE]]</title>
+<meta charset="utf-8">
+<style>
+
+</style>
+<script>
+
+</script>
+</head>
+<body>
+[[HEADER]]
+[[CONTENT]]
+[[FOOTER]]
+</body>
+</html>


### PR DESCRIPTION
I believe this is a good point to merge back to initial commit because it has set a couple of standards.  

1. The way I'm documenting the class adds seems to be intuitive for you to build the classes.  In the Report class you captured everything I wanted, included the json getter, and all of it's attributes, including the future considerations to the extent that you could.
2. It shows me how you want to structure the code for the classes, keeping it neat and tidy, with areas for documenting the class as well.

Closes #4 Add class report
Closes #16  Add HTML Export

Can this also be used to solve our outstanding question #3.  It seems like this is point 1, get it to HTML?  